### PR TITLE
Address output for tf12 when empty string

### DIFF
--- a/group/lc/outputs.tf
+++ b/group/lc/outputs.tf
@@ -1,13 +1,14 @@
 # Outputs
 
 output "lc_id" {
-  value = coalesce(
-    join(",", aws_launch_configuration.lc.*.id),
-    join(",", aws_launch_configuration.lc_ebs.*.id),
-  )
+  value = join(",",
+    compact(
+      coalescelist(
+        aws_launch_configuration.lc.*.id,
+        aws_launch_configuration.lc_ebs.*.id,
+  [""])))
 }
 
 output "sg_id" {
   value = aws_security_group.sg_asg.id
 }
-


### PR DESCRIPTION
* Addresses coalesce beahvior change for TF 0.12 see [GH-21370](https://github.com/hashicorp/terraform/issues/21370)
* Now will handle empty value in output without error